### PR TITLE
Fix linter CLI function and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ myNewProject/
 
 ### Run the GUI naming linter
 ```bash
-runLinter src/
+runLinter <file_or_dir>
 ```
 
 Checks for violations of variable/class naming and logging message style.

--- a/organiseMyProjects/HELP.md
+++ b/organiseMyProjects/HELP.md
@@ -13,12 +13,12 @@ This tool checks Python GUI code for compliance with common readability and cons
 ### CLI
 Run this from the command line:
 ```bash
-python runLinter.py path/to/your_script.py
+runLinter path/to/your_script.py
 ```
 
 ### Programmatic
 ```python
-from guiNamingLinter import lint_file
+from organiseMyProjects.guiNamingLinter import lint_file
 lint_file("your_script.py")
 ```
 

--- a/organiseMyProjects/createProject.py
+++ b/organiseMyProjects/createProject.py
@@ -77,7 +77,7 @@ def setupLogging(title: str) -> logging.Logger:
     hooks:
       - id: gui-naming-linter
         name: GUI Naming Linter
-        entry: python guiNamingLinter.py src/
+        entry: runLinter src/
         language: system
         types: [python]
 """)

--- a/organiseMyProjects/guiNamingLinter.py
+++ b/organiseMyProjects/guiNamingLinter.py
@@ -136,14 +136,17 @@ def lintGuiNaming(directory):
                         print(f"  Line {lineno}: '{name}' should follow naming rule for {ruleType}.")
                 else:
                     print(f"{filename}: OK")
-def lintFile(filepath):
+def lint_file(filepath):
     print(f"\nLinting: {filepath}\n" + "-"*50)
     violations = checkFile(filepath)
     if violations:
         for name, ruleType, lineno in violations:
             print(f"  Line {lineno}: '{name}' should follow naming rule for {ruleType}.")
     else:
-            print("  OK")
+        print("  OK")
+
+# Backwards compatibility
+lintFile = lint_file
 
 if __name__ == "__main__":
     import sys

--- a/organiseMyProjects/runLinter.py
+++ b/organiseMyProjects/runLinter.py
@@ -1,23 +1,28 @@
 """
 runLinter.py - Entry point for GUI Naming Linter
 
-This script allows you to run guiNamingLinter.py via the command line.
+This script exposes the GUI naming linter as a command line tool.
 
 Usage:
-    python runLinter.py my_script.py
+    runLinter <file_or_dir>
 """
 
+import os
 import sys
-from organiseMyProjects.guiNamingLinter import lint_file
+from organiseMyProjects.guiNamingLinter import lint_file, lintGuiNaming
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python runLinter.py <path-to-python-file>")
+        print("Usage: runLinter <file_or_dir>")
         return
 
-    filepath = sys.argv[1]
-    print(f"Linting: {filepath}")
-    lint_file(filepath)
+    target = sys.argv[1]
+    print(f"Linting: {target}")
+
+    if os.path.isdir(target):
+        lintGuiNaming(target)
+    else:
+        lint_file(target)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- rename `lintFile` to `lint_file` and keep backwards alias
- make `runLinter` command handle files or directories and show new usage
- adjust README and HELP docs for new CLI form
- fix generated pre-commit hook entry to call `runLinter`

## Testing
- `pytest -q`
- `python -m compileall organiseMyProjects`


------
https://chatgpt.com/codex/tasks/task_e_68890fe7a57c832884cea68e60ae6222