### PR TITLE
Use logs directory for logging

### DIFF
--- a/organiseMyProjects/createProject.py
+++ b/organiseMyProjects/createProject.py
@@ -50,7 +50,7 @@ def setupLogging(title: str) -> logging.Logger:
     title = title.replace(" ", "")
     logger = logging.getLogger(title)
     if not logger.handlers:
-        logDir = os.getcwd()
+        logDir = os.path.join(os.getcwd(), "logs")
         os.makedirs(logDir, exist_ok=True)
         logDate = datetime.datetime.now().strftime("%Y%m%d")
         logFilePath = os.path.join(logDir, f"{title}.{logDate}.log")

--- a/organiseMyProjects/logUtils.py
+++ b/organiseMyProjects/logUtils.py
@@ -20,7 +20,7 @@ def setupLogging(title: str) -> logging.Logger:
     title = title.replace(" ", "")
     logger = logging.getLogger(title)
     if not logger.handlers:
-        logDir = os.getcwd()
+        logDir = os.path.join(os.getcwd(), "logs")
         os.makedirs(logDir, exist_ok=True)
         logDate = datetime.datetime.now().strftime("%Y%m%d")
         logFilePath = os.path.join(logDir, f"{title}.{logDate}.log")


### PR DESCRIPTION
## Summary
- ensure logs are written inside a `logs/` folder
- update logging template used when scaffolding projects

## Testing
- `python -m py_compile organiseMyProjects/logUtils.py organiseMyProjects/createProject.py`


------
https://chatgpt.com/codex/tasks/task_e_6889166ae948832889160764bb42f048