### PR TITLE
Write main.py to project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Creates:
 ```
 myNewProject/
 ├── src/
-│   ├── main.py
 │   └── logUtils.py
+├── main.py
 ├── ui/
 │   ├── mainMenu.py
 │   ├── baseFrame.py

--- a/organiseMyProjects/createProject.py
+++ b/organiseMyProjects/createProject.py
@@ -44,13 +44,8 @@ def createProject(projectName):
     shutil.copy(TEMPLATE_DIR / "guiNamingLinter.py", basePath / "tests" / "guiNamingLinter.py")
 
     # Create main.py starter
-    mainPath = basePath / "src" / "main.py"
-    mainPath.write_text("""from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-
-from logUtils import setupLogging
+    mainPath = basePath / "main.py"
+    mainPath.write_text("""from src.logUtils import setupLogging
 from ui.mainMenu import mainMenu
 
 logger = setupLogging("main")


### PR DESCRIPTION
## Summary
- place `main.py` in the project root when creating a project
- clean up generated `main.py` imports and remove `sys.path` manipulation
- update README example tree to show new location of `main.py`

## Testing
- `python -m py_compile organiseMyProjects/createProject.py`


------
https://chatgpt.com/codex/tasks/task_e_688a2131c1648328986d54484f6614c6