### PR TITLE
feat: introduce thisApplication variable, replace print with logger in createProject, add --confirm dry-run

### DIFF
--- a/.github/additional-copilot-instructions.md
+++ b/.github/additional-copilot-instructions.md
@@ -102,7 +102,7 @@ organiseMyProjects/
 
 **[PACKAGE]** - Package utilities that remain in organiseMyProjects and are NOT copied to new projects:
 - `createProject.py` - The scaffolding tool itself
-- `logUtils.py` - Package-level logging utility (accessible via `from organiseMyProjects.logUtils import getLogger`)
+- `logUtils.py` - Package-level logging utility (accessible via `from organiseMyProjects.logUtils import getLogger, thisApplication`)
 - `HELP.md` - Documentation
 
 **[TEMPLATE]** - Template files that are copied to new projects:
@@ -164,11 +164,12 @@ organiseMyProjects/
 - **Purpose**: Package-level logging utility
 - **Type**: PACKAGE UTILITY (NOT copied to new projects, but accessible via package import)
 - **Key Functions**:
+  - `thisApplication` - name of the current application (derived from caller module) and passed to `getLogger` for consistent logger naming
   - `getLogger(name)` - Get a logger instance (from standard logging module)
   - `setupLogging(title)` - Configure logging with file handler
 - **Usage**: 
-  - From package: `from organiseMyProjects.logUtils import getLogger`
-  - Example: `logger = getLogger('myApp')`
+  - From package: `from organiseMyProjects.logUtils import getLogger, thisApplication`
+  - Example: `logger = getLogger(thisApplication)`
 - **Note**: New projects should implement their own logging based on their needs, but can reference this utility for setup patterns
 
 ### globalVars.py
@@ -229,9 +230,9 @@ lintGuiNaming("path/to/directory")
 runLinter()  # CLI interface
 
 # Use logging utility
-from organiseMyProjects.logUtils import getLogger
-logger = getLogger("myApp")
-logger.info("Application started")
+from organiseMyProjects.logUtils import getLogger, thisApplication
+logger = getLogger(thisApplication)
+logger.info("This is a log message")
 ```
 
 ## Development Workflow

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -132,14 +132,14 @@ All projects must use centralized logging.
 **Module-level initialisation** (bare logger, no dryRun yet):
 
 ``` python
-from organiseMyProjects.logUtils import getLogger
-logger = getLogger("projectName")
+from organiseMyProjects.logUtils import getLogger, thisApplication
+logger = getLogger(thisApplication, includeConsole=False)
 ```
 
 **Re-initialise in `main()` with full parameters** (logDir, includeConsole, dryRun):
 
 ``` python
-logger = getLogger("projectName", logDir=logDir, includeConsole=True, dryRun=dryRun)
+logger = getLogger(thisApplication, logDir=logDir, includeConsole=True, dryRun=dryRun)
 ```
 
 **Semantic log methods:**
@@ -164,11 +164,11 @@ if not dryRun:
 **`drawBox()` for prominent log entries:**
 
 ``` python
-from organiseMyProjects.logUtils import getLogger, drawBox
+from organiseMyProjects.logUtils import getLogger, thisApplication, drawBox
 drawBox("Sync complete\n3 updated, 0 failed", logger=logger)
 ```
 
--   Initialize logging at module level with `getLogger("projectName")`\
+-   Initialize logging at module level with `getLogger(thisApplication)`\
 -   Re-initialize in `main()` passing `logDir`, `includeConsole`, and `dryRun`\
 -   Use `logger.doing()` / `logger.done()` to bracket major operations\
 -   Use `logger.action()` for operations that are skipped in dry-run — never construct a manual `prefix = "[] "` string\

--- a/documentation/DEVELOPER.md
+++ b/documentation/DEVELOPER.md
@@ -29,8 +29,9 @@ The main module responsible for project scaffolding functionality.
 Centralised logging utilities shared across organiseMyProjects tooling.
 
 **Key Functions:**
-- `setupLogging(title, logDir, level, includeConsole)` - Create/retrieve a named logger with a `FileHandler`
-- `getLogger(name, logDir, level, includeConsole)` - Convenience wrapper around `setupLogging`
+- `thisApplication` - Name of the application 
+- `setupLogging(thisApplication, logDir, level, includeConsole)` - Create/retrieve a named logger with a `FileHandler`
+- `getLogger(thisApplication, logDir, level, includeConsole)` - Convenience wrapper around `setupLogging`
 - `setLogLevel(level, targetLogger)` - Change the log level of a logger at runtime
 - `cleanOldLogFiles(logDir, daysToKeep)` - Remove log files older than the specified number of days
 - `drawBox(message, border_char, corner_char, side_char, padding, logger)` - Print or log a text message surrounded by a Unicode box
@@ -58,13 +59,13 @@ Draws an ASCII/Unicode box around a (potentially multi-line) message to make it 
 **Usage Examples:**
 
 ```python
-from organiseMyProjects.logUtils import drawBox, getLogger
+from organiseMyProjects.logUtils import drawBox, getLogger, thisApplication
 
 # Print to stdout
 drawBox("Deployment complete")
 
 # Log via a logger instance
-log = getLogger("MyApp")
+log = getLogger(thisApplication)
 drawBox("[ERROR] Database connection failed\nAttempted 3 retries.", logger=log)
 
 # Custom box characters

--- a/organiseMyProjects/__init__.py
+++ b/organiseMyProjects/__init__.py
@@ -20,10 +20,10 @@ Template files (copied to new projects):
 
 Usage:
     from organiseMyProjects import createProject, runLinter
-    from organiseMyProjects.logUtils import getLogger
+    from organiseMyProjects.logUtils import getLogger, thisApplication
 """
 
-__version__ = "0.1"
+__version__ = "0.2"
 
 # Expose main functionality for programmatic use
 from . import createProject

--- a/organiseMyProjects/createProject.py
+++ b/organiseMyProjects/createProject.py
@@ -5,6 +5,10 @@ import subprocess
 import argparse
 from pathlib import Path
 
+from organiseMyProjects.logUtils import getLogger, thisApplication
+
+logger = getLogger(thisApplication, includeConsole=False)  # placeholder; re-initialised with Path(__file__).stem in main()
+
 # text templates used when creating or updating projects
 GITIGNORE_CONTENT = "__pycache__/\nlogs/\n*.log\n*.pyc\n"
 REQUIREMENTS_CONTENT = "pywin32\n"
@@ -63,107 +67,122 @@ VSCODE_SETTINGS_CONTENT = """{
 
 TEMPLATE_DIR = Path(__file__).resolve().parent
 
-def createProject(projectName):
+def createProject(projectName, dryRun: bool = False):
 
     basePath = Path(projectName)
     if basePath.exists():
-        print(f"Project '{projectName}' already exists.")
+        logger.info(f"project '{projectName}' already exists")
         return
 
-    print(f"Creating project at {basePath}...")
+    logger.doing(f"creating project at {basePath}")
 
     # Create folders
-    print("Creating directories...")
-    (basePath / "src").mkdir(parents=True)
-    (basePath / "ui").mkdir()
-    (basePath / "tests").mkdir()
-    (basePath / "logs").mkdir()
-    (basePath / ".github").mkdir()
+    logger.action("creating directories")
+    if not dryRun:
+        (basePath / "src").mkdir(parents=True)
+        (basePath / "ui").mkdir()
+        (basePath / "tests").mkdir()
+        (basePath / "logs").mkdir()
+        (basePath / ".github").mkdir()
 
-    # Make directories importable packages
-    (basePath / "src" / "__init__.py").touch()
-    (basePath / "ui" / "__init__.py").touch()
+        # Make directories importable packages
+        (basePath / "src" / "__init__.py").touch()
+        (basePath / "ui" / "__init__.py").touch()
 
     # Create core files
-    print("Writing core files...")
-    (basePath / ".gitignore").write_text(GITIGNORE_CONTENT)
-    (basePath / "requirements.txt").write_text(REQUIREMENTS_CONTENT)
-    (basePath / "dev-requirements.txt").write_text(DEV_REQUIREMENTS_CONTENT)
-    (basePath / ".env").write_text(ENV_CONTENT)
-    (basePath / "README.md").write_text(
-        f"# {projectName}\n\nProject scaffold created by createProject.py\n"
-    )
+    logger.action("writing core files")
+    if not dryRun:
+        (basePath / ".gitignore").write_text(GITIGNORE_CONTENT)
+        (basePath / "requirements.txt").write_text(REQUIREMENTS_CONTENT)
+        (basePath / "dev-requirements.txt").write_text(DEV_REQUIREMENTS_CONTENT)
+        (basePath / ".env").write_text(ENV_CONTENT)
+        (basePath / "README.md").write_text(
+            f"# {projectName}\n\nProject scaffold created by createProject.py\n"
+        )
 
     # Copy the guidelines file
     srcGuidelines = TEMPLATE_DIR.parent / "projectGuidelines.md"
     if srcGuidelines.exists():
-        print("Copying project guidelines...")
-        shutil.copy(srcGuidelines, basePath / "projectGuidelines.md")
+        logger.action("copying project guidelines")
+        if not dryRun:
+            shutil.copy(srcGuidelines, basePath / "projectGuidelines.md")
 
     # Copy the copilot instructions file
     srcCopilotInstructions = TEMPLATE_DIR.parent / ".github" / "copilot-instructions.md"
     if srcCopilotInstructions.exists():
-        print("Copying copilot instructions...")
-        shutil.copy(srcCopilotInstructions, basePath / ".github" / "copilot-instructions.md")
+        logger.action("copying copilot instructions")
+        if not dryRun:
+            shutil.copy(srcCopilotInstructions, basePath / ".github" / "copilot-instructions.md")
 
     # Copy template modules into the new project
-    print("Copying template modules...")
-    shutil.copy(TEMPLATE_DIR / "globalVars.py", basePath / "src" / "globalVars.py")
-    shutil.copy(TEMPLATE_DIR / "styleUtils.py", basePath / "ui" / "styleUtils.py")
-    shutil.copy(TEMPLATE_DIR / "mainMenu.py", basePath / "ui" / "mainMenu.py")
-    shutil.copy(TEMPLATE_DIR / "baseFrame.py", basePath / "ui" / "baseFrame.py")
-    shutil.copy(TEMPLATE_DIR / "frameTemplate.py", basePath / "ui" / "frameTemplate.py")
-    shutil.copy(TEMPLATE_DIR / "statusFrame.py", basePath / "ui" / "statusFrame.py")
-    shutil.copy(TEMPLATE_DIR / "runLinter.py", basePath / "tests" / "runLinter.py")
-    shutil.copy(TEMPLATE_DIR / "guiNamingLinter.py", basePath / "tests" / "guiNamingLinter.py")
+    logger.action("copying template modules")
+    if not dryRun:
+        shutil.copy(TEMPLATE_DIR / "globalVars.py", basePath / "src" / "globalVars.py")
+        shutil.copy(TEMPLATE_DIR / "styleUtils.py", basePath / "ui" / "styleUtils.py")
+        shutil.copy(TEMPLATE_DIR / "mainMenu.py", basePath / "ui" / "mainMenu.py")
+        shutil.copy(TEMPLATE_DIR / "baseFrame.py", basePath / "ui" / "baseFrame.py")
+        shutil.copy(TEMPLATE_DIR / "frameTemplate.py", basePath / "ui" / "frameTemplate.py")
+        shutil.copy(TEMPLATE_DIR / "statusFrame.py", basePath / "ui" / "statusFrame.py")
+        shutil.copy(TEMPLATE_DIR / "runLinter.py", basePath / "tests" / "runLinter.py")
+        shutil.copy(TEMPLATE_DIR / "guiNamingLinter.py", basePath / "tests" / "guiNamingLinter.py")
 
     # Create main.py starter
-    mainPath = basePath / "main.py"
-    mainPath.write_text(MAIN_PY_CONTENT)
+    logger.action("writing main.py")
+    if not dryRun:
+        (basePath / "main.py").write_text(MAIN_PY_CONTENT)
 
     # Create .pre-commit-config.yaml
-    preCommitPath = basePath / ".pre-commit-config.yaml"
-    preCommitPath.write_text(PRECOMMIT_CONTENT)
+    logger.action("writing .pre-commit-config.yaml")
+    if not dryRun:
+        (basePath / ".pre-commit-config.yaml").write_text(PRECOMMIT_CONTENT)
 
     # Create pytest config
-    (basePath / "pytest.ini").write_text(PYTEST_INI_CONTENT)
+    logger.action("writing pytest.ini")
+    if not dryRun:
+        (basePath / "pytest.ini").write_text(PYTEST_INI_CONTENT)
 
     # Create VSCode settings
-    (basePath / ".vscode").mkdir(exist_ok=True)
-    (basePath / ".vscode" / "settings.json").write_text(VSCODE_SETTINGS_CONTENT)
+    logger.action("writing .vscode/settings.json")
+    if not dryRun:
+        (basePath / ".vscode").mkdir(exist_ok=True)
+        (basePath / ".vscode" / "settings.json").write_text(VSCODE_SETTINGS_CONTENT)
 
     # Initialize git and install pre-commit
-    try:
-        print("Initializing git repository...")
-        subprocess.run(["git", "init"], cwd=basePath, check=True)
-        subprocess.run(["pre-commit", "install"], cwd=basePath, check=True)
-        print("Git initialized and pre-commit hook installed.")
-    except Exception as e:
-        print(f"Could not initialize git or install pre-commit: {e}")
+    logger.action("initializing git repository")
+    if not dryRun:
+        try:
+            subprocess.run(["git", "init"], cwd=basePath, check=True)
+            subprocess.run(["pre-commit", "install"], cwd=basePath, check=True)
+            logger.done("git initialized and pre-commit hook installed")
+        except Exception as e:
+            logger.error(f"Could not initialize git or install pre-commit: {e}")
 
-    print(f"Project '{projectName}' created with full structure.")
+    logger.done(f"project '{projectName}' created")
 
 
-def _backup_file(dest: Path) -> None:
+def _backup_file(dest: Path, dryRun: bool = False) -> None:
     """Rename dest to {stem}.YYMMDD{suffix} before overwriting."""
     if dest.exists():
         stamp = datetime.date.today().strftime("%y%m%d")
         backup = dest.with_name(f"{dest.stem}.{stamp}{dest.suffix}")
-        dest.rename(backup)
-        print(f"Backed up {dest.name} → {backup.name}")
+        logger.action(f"backed up {dest.name} → {backup.name}")
+        if not dryRun:
+            dest.rename(backup)
 
 
-def _copy_if_newer(src: Path, dest: Path):
+def _copy_if_newer(src: Path, dest: Path, dryRun: bool = False):
 
     """Copy src to dest if dest doesn't exist or src is newer."""
-    dest.parent.mkdir(parents=True, exist_ok=True)
+    if not dryRun:
+        dest.parent.mkdir(parents=True, exist_ok=True)
     if not dest.exists() or src.stat().st_mtime > dest.stat().st_mtime:
-        _backup_file(dest)
-        shutil.copy(src, dest)
-        print(f"Updated {dest}")
+        _backup_file(dest, dryRun)
+        logger.action(f"updated {dest}")
+        if not dryRun:
+            shutil.copy(src, dest)
 
 
-def _update_text_file(dest: Path, content: str):
+def _update_text_file(dest: Path, content: str, dryRun: bool = False):
 
     """Write *content* to *dest* if the file is missing or differs.
 
@@ -171,7 +190,8 @@ def _update_text_file(dest: Path, content: str):
     the default text encoding may not be UTF-8.
     """
 
-    dest.parent.mkdir(parents=True, exist_ok=True)
+    if not dryRun:
+        dest.parent.mkdir(parents=True, exist_ok=True)
     new_bytes = content.encode("utf-8")
     try:
         current = dest.read_bytes() if dest.exists() else None
@@ -179,47 +199,49 @@ def _update_text_file(dest: Path, content: str):
         current = None
 
     if current != new_bytes:
-        _backup_file(dest)
-        dest.write_bytes(new_bytes)
-        print(f"Updated {dest}")
+        _backup_file(dest, dryRun)
+        logger.action(f"updated {dest}")
+        if not dryRun:
+            dest.write_bytes(new_bytes)
 
 
-def updateProject(projectName):
+def updateProject(projectName, dryRun: bool = False):
 
     basePath = Path(projectName)
     if not basePath.exists():
-        print(f"Project '{projectName}' does not exist.")
+        logger.info(f"project '{projectName}' does not exist")
         return
 
-    print(f"Updating project at {basePath}...")
-    print("Ensuring directories and packages...")
+    logger.doing(f"updating project at {basePath}")
+    logger.action("ensuring directories and packages")
+    if not dryRun:
+        for folder in ["src", "ui", "tests", "logs", ".github"]:
+            (basePath / folder).mkdir(parents=True, exist_ok=True)
 
-    for folder in ["src", "ui", "tests", "logs", ".github"]:
-        (basePath / folder).mkdir(parents=True, exist_ok=True)
+        (basePath / "src" / "__init__.py").touch(exist_ok=True)
+        (basePath / "ui" / "__init__.py").touch(exist_ok=True)
 
-    (basePath / "src" / "__init__.py").touch(exist_ok=True)
-    (basePath / "ui" / "__init__.py").touch(exist_ok=True)
-
-    _update_text_file(basePath / ".gitignore", GITIGNORE_CONTENT)
-    _update_text_file(basePath / "requirements.txt", REQUIREMENTS_CONTENT)
-    _update_text_file(basePath / "dev-requirements.txt", DEV_REQUIREMENTS_CONTENT)
-    _update_text_file(basePath / ".env", ENV_CONTENT)
+    _update_text_file(basePath / ".gitignore", GITIGNORE_CONTENT, dryRun)
+    _update_text_file(basePath / "requirements.txt", REQUIREMENTS_CONTENT, dryRun)
+    _update_text_file(basePath / "dev-requirements.txt", DEV_REQUIREMENTS_CONTENT, dryRun)
+    _update_text_file(basePath / ".env", ENV_CONTENT, dryRun)
     _update_text_file(
         basePath / "README.md",
         f"# {projectName}\n\nProject scaffold created by createProject.py\n",
+        dryRun,
     )
 
     srcGuidelines = TEMPLATE_DIR.parent / "projectGuidelines.md"
     if srcGuidelines.exists():
-        print("Checking guidelines file...")
-        _copy_if_newer(srcGuidelines, basePath / "projectGuidelines.md")
+        logger.info("checking guidelines file")
+        _copy_if_newer(srcGuidelines, basePath / "projectGuidelines.md", dryRun)
 
     srcCopilotInstructions = TEMPLATE_DIR.parent / ".github" / "copilot-instructions.md"
     if srcCopilotInstructions.exists():
-        print("Checking copilot instructions...")
-        _copy_if_newer(srcCopilotInstructions, basePath / ".github" / "copilot-instructions.md")
+        logger.info("checking copilot instructions")
+        _copy_if_newer(srcCopilotInstructions, basePath / ".github" / "copilot-instructions.md", dryRun)
 
-    print("Checking template modules...")
+    logger.info("checking template modules")
     modules = [
         ("globalVars.py", "src/globalVars.py"),
         ("styleUtils.py", "ui/styleUtils.py"),
@@ -231,17 +253,20 @@ def updateProject(projectName):
         ("guiNamingLinter.py", "tests/guiNamingLinter.py"),
     ]
     for src_name, dest_rel in modules:
-        _copy_if_newer(TEMPLATE_DIR / src_name, basePath / dest_rel)
+        _copy_if_newer(TEMPLATE_DIR / src_name, basePath / dest_rel, dryRun)
 
-    _update_text_file(basePath / "main.py", MAIN_PY_CONTENT)
-    _update_text_file(basePath / ".pre-commit-config.yaml", PRECOMMIT_CONTENT)
-    _update_text_file(basePath / "pytest.ini", PYTEST_INI_CONTENT)
-    (basePath / ".vscode").mkdir(parents=True, exist_ok=True)
-    _update_text_file(basePath / ".vscode" / "settings.json", VSCODE_SETTINGS_CONTENT)
+    _update_text_file(basePath / "main.py", MAIN_PY_CONTENT, dryRun)
+    _update_text_file(basePath / ".pre-commit-config.yaml", PRECOMMIT_CONTENT, dryRun)
+    _update_text_file(basePath / "pytest.ini", PYTEST_INI_CONTENT, dryRun)
+    if not dryRun:
+        (basePath / ".vscode").mkdir(parents=True, exist_ok=True)
+    _update_text_file(basePath / ".vscode" / "settings.json", VSCODE_SETTINGS_CONTENT, dryRun)
 
-    print(f"Project '{projectName}' updated.")
+    logger.done(f"project '{projectName}' updated")
 
 def main():
+    global logger
+    _name = Path(__file__).stem
     
     parser = argparse.ArgumentParser(
         description="Create or update a project scaffold"
@@ -258,16 +283,25 @@ def main():
         action="store_true",
         help="Refresh an existing project instead of creating a new one",
     )
+    parser.add_argument(
+        "--confirm",
+        dest="confirm",
+        action="store_true",
+        help="execute changes (default is dry-run)",
+    )
 
     args = parser.parse_args()
+    dryRun = not args.confirm
+    logger = getLogger(_name, includeConsole=True, dryRun=dryRun)
+    logger.doing(_name)
 
     if args.update:
         project_path = args.project or Path.cwd()
-        updateProject(project_path)
+        updateProject(project_path, dryRun=dryRun)
     else:
         if args.project is None:
             parser.error("the following arguments are required: project")
-        createProject(args.project)
+        createProject(args.project, dryRun=dryRun)
 
 
 if __name__ == '__main__':

--- a/organiseMyProjects/createProject.py
+++ b/organiseMyProjects/createProject.py
@@ -292,6 +292,7 @@ def main():
 
     args = parser.parse_args()
     dryRun = not args.confirm
+    print (thisApplication)
     logger = getLogger(thisApplication, includeConsole=True, dryRun=dryRun)
     logger.doing(thisApplication)
 

--- a/organiseMyProjects/createProject.py
+++ b/organiseMyProjects/createProject.py
@@ -266,7 +266,7 @@ def updateProject(projectName, dryRun: bool = False):
 
 def main():
     global logger
-    _name = Path(__file__).stem
+    thisApplication = Path(__file__).stem
     
     parser = argparse.ArgumentParser(
         description="Create or update a project scaffold"
@@ -292,8 +292,8 @@ def main():
 
     args = parser.parse_args()
     dryRun = not args.confirm
-    logger = getLogger(_name, includeConsole=True, dryRun=dryRun)
-    logger.doing(_name)
+    logger = getLogger(thisApplication, includeConsole=True, dryRun=dryRun)
+    logger.doing(thisApplication)
 
     if args.update:
         project_path = args.project or Path.cwd()

--- a/organiseMyProjects/logUtils.py
+++ b/organiseMyProjects/logUtils.py
@@ -17,7 +17,7 @@ from typing import Any, MutableMapping, Optional
 _initialized_log_files: set[str] = set()
 
 _DRY_RUN_PREFIX = "[] "
-
+thisApplication = "dummy" # this will be overridden by users to set the application name in logs, e.g. "myTool" or "createProject"
 
 class _OrganiseLoggerAdapter(logging.LoggerAdapter):
     """Logger adapter providing semantic log methods with optional dry-run prefixing."""

--- a/organiseMyProjects/logUtils.py
+++ b/organiseMyProjects/logUtils.py
@@ -35,19 +35,19 @@ class _OrganiseLoggerAdapter(logging.LoggerAdapter):
 
     def info(self, message: str, *args, **kwargs) -> None:
         """Log general information: '...message'"""
-        self.logger.info(f"...{message}", *args, **kwargs)
+        self.logger.info(f"...{self._prefix}{message}", *args, **kwargs)
 
     def doing(self, message: str) -> None:
         """Log a major action being taken: 'message...'"""
-        self.logger.info(f"{message}...")
+        self.logger.info(f"{self._prefix}{message}...")
 
     def done(self, message: str) -> None:
         """Log a completed action: '...message'"""
-        self.logger.info(f"...{message}")
+        self.logger.info(f"...{self._prefix}{message}")
 
     def value(self, message: str, variable) -> None:
         """Log a name-value pair: '...message: variable'"""
-        self.logger.info(f"...{message}: {variable}")
+        self.logger.info(f"...{self._prefix}{message}: {variable}")
 
     def action(self, message: str, *args, **kwargs) -> None:
         """Log a name-value pair: '...{prefix}message'"""

--- a/organiseMyProjects/logUtils.py
+++ b/organiseMyProjects/logUtils.py
@@ -28,9 +28,7 @@ class _OrganiseLoggerAdapter(logging.LoggerAdapter):
         self._prefix = _DRY_RUN_PREFIX if dryRun else ""
 
     def process(self, msg: str, kwargs: MutableMapping[str, Any]) -> tuple[str, MutableMapping[str, Any]]:
-        """For non-semantic calls (warning, error, debug), add dryRun prefix."""
-        if self._dryRun:
-            return f"{_DRY_RUN_PREFIX}{msg}", kwargs
+        """Pass through non-semantic calls (warning, error, debug) unchanged."""
         return msg, kwargs
 
     def info(self, message: str, *args, **kwargs) -> None:
@@ -97,7 +95,7 @@ def _setupLogging(
         logger.addHandler(fileHandler)
         _initialized_log_files.add(str(logFile))
 
-    if includeConsole and not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+    if includeConsole and not any(type(h) is logging.StreamHandler for h in logger.handlers):
         consoleHandler = logging.StreamHandler()
         consoleFormatter = logging.Formatter("%(levelname)s - %(message)s")
         consoleHandler.setFormatter(consoleFormatter)

--- a/organiseMyProjects/logUtils.py
+++ b/organiseMyProjects/logUtils.py
@@ -35,19 +35,19 @@ class _OrganiseLoggerAdapter(logging.LoggerAdapter):
 
     def info(self, message: str, *args, **kwargs) -> None:
         """Log general information: '...message'"""
-        self.logger.info(f"...{self._prefix}{message}", *args, **kwargs)
+        self.logger.info(f"...{message}", *args, **kwargs)
 
     def doing(self, message: str) -> None:
         """Log a major action being taken: 'message...'"""
-        self.logger.info(f"{self._prefix}{message}...")
+        self.logger.info(f"{message}...")
 
     def done(self, message: str) -> None:
         """Log a completed action: '...message'"""
-        self.logger.info(f"...{self._prefix}{message}")
+        self.logger.info(f"...{message}")
 
     def value(self, message: str, variable) -> None:
         """Log a name-value pair: '...message: variable'"""
-        self.logger.info(f"...{self._prefix}{message}: {variable}")
+        self.logger.info(f"...{message}: {variable}")
 
     def action(self, message: str, *args, **kwargs) -> None:
         """Log a name-value pair: '...{prefix}message'"""
@@ -116,12 +116,12 @@ def getLogger(
     Convenience wrapper used by other scripts.
 
     Returns an _OrganiseLoggerAdapter with semantic log methods:
-      doing(message)           – logs '{prefix}message...'
-      done(message)            – logs '...{prefix}message'
-      info(message)            – logs '...{prefix}message'
-      value(message, variable) – logs '...{prefix}message: variable'
-
-    Pass dryRun=True to insert '[] ' into every formatted message.
+      doing(message)           – logs 'message...'
+      done(message)            – logs '...message'
+      info(message)            – logs '...message'
+      value(message, variable) – logs '...message: variable'
+      action(message)          – logs '...{prefix}message'
+    Pass dryRun=True to insert '[] ' only for action
     """
     logger = _setupLogging(name, logDir=logDir, level=level, includeConsole=includeConsole)
     return _OrganiseLoggerAdapter(logger, dryRun=dryRun)

--- a/syncCopilotInstructions.py
+++ b/syncCopilotInstructions.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 import requests
 
-from organiseMyProjects.logUtils import getLogger
+from organiseMyProjects.logUtils import getLogger, thisApplication
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -200,7 +200,8 @@ def main() -> None:
     dryRun = not args.confirm
     prefix = "[] " if dryRun else ""
 
-    logger = getLogger("syncCopilotInstructions", includeConsole=False)
+    thisApplication = Path(__file__).stem
+    logger = getLogger(thisApplication, includeConsole=False)
 
     # Resolve the GitHub token
     token = args.token or os.environ.get("GITHUB_TOKEN", "")

--- a/tests/testCreateProject.py
+++ b/tests/testCreateProject.py
@@ -2,6 +2,7 @@
 Tests for createProject.py functionality.
 """
 import datetime
+import logging
 import pytest
 import os
 import sys
@@ -128,15 +129,15 @@ class TestCreateProject:
         assert not (projectPath / "src" / "logUtils.py").exists(), "logUtils.py should NOT be copied to new projects"
         assert not (projectPath / "createProject.py").exists(), "createProject.py should NOT be copied to new projects"
     
-    def testCreateProjectAlreadyExists(self, temp_dir, sample_project_name, capsys):
+    def testCreateProjectAlreadyExists(self, temp_dir, sample_project_name, caplog):
         """Test behavior when project directory already exists."""
         projectPath = temp_dir / sample_project_name
         projectPath.mkdir()  # Create directory first
         
-        createProject(str(projectPath))
+        with caplog.at_level(logging.INFO):
+            createProject(str(projectPath))
         
-        captured = capsys.readouterr()
-        assert "already exists" in captured.out
+        assert "already exists" in caplog.text
     
     def testCreateProjectCopilotInstructions(self, temp_dir, sample_project_name):
         """Test that copilot instructions are copied from the .github/ directory."""
@@ -168,14 +169,14 @@ class TestUpdateProject:
         assert (projectPath / "logs").exists()
         assert (projectPath / ".github").exists()
     
-    def testUpdateProjectNonexistent(self, temp_dir, sample_project_name, capsys):
+    def testUpdateProjectNonexistent(self, temp_dir, sample_project_name, caplog):
         """Test behavior when trying to update non-existent project."""
         projectPath = temp_dir / sample_project_name
         
-        updateProject(str(projectPath))
+        with caplog.at_level(logging.INFO):
+            updateProject(str(projectPath))
         
-        captured = capsys.readouterr()
-        assert "does not exist" in captured.out
+        assert "does not exist" in caplog.text
 
     def testUpdateProjectPytestIni(self, temp_dir, sample_project_name):
         """Test that updateProject creates/updates pytest.ini with the correct content."""
@@ -358,3 +359,75 @@ class TestBackupFile:
         stamp = datetime.date.today().strftime("%y%m%d")
         backup = temp_dir / f"config.{stamp}.txt"
         assert not backup.exists(), "No backup should be created when content is unchanged"
+
+
+class TestDryRun:
+    """Test that dry-run mode logs actions without writing any files."""
+
+    def testCreateProjectDryRunNoFilesCreated(self, temp_dir, sample_project_name):
+        """Test that createProject in dry-run mode does not create the project directory."""
+        projectPath = temp_dir / sample_project_name
+
+        createProject(str(projectPath), dryRun=True)
+
+        assert not projectPath.exists(), "Project directory must not be created in dry-run mode"
+
+    def testCreateProjectDryRunLogsActions(self, temp_dir, sample_project_name, caplog):
+        """Test that createProject in dry-run mode logs the actions it would take."""
+        projectPath = temp_dir / sample_project_name
+
+        with caplog.at_level(logging.INFO):
+            createProject(str(projectPath), dryRun=True)
+
+        assert "creating project" in caplog.text
+        assert "creating directories" in caplog.text
+        assert "writing core files" in caplog.text
+
+    def testUpdateProjectDryRunNoFilesModified(self, temp_dir, sample_project_name):
+        """Test that updateProject in dry-run mode does not modify existing files."""
+        projectPath = temp_dir / sample_project_name
+        projectPath.mkdir()
+        (projectPath / "src").mkdir()
+        sentinel = projectPath / "src" / "globalVars.py"
+        sentinel.write_text("original content")
+
+        updateProject(str(projectPath), dryRun=True)
+
+        assert sentinel.read_text() == "original content", "File must not be modified in dry-run mode"
+
+    def testUpdateProjectDryRunLogsActions(self, temp_dir, sample_project_name, caplog):
+        """Test that updateProject in dry-run mode logs the actions it would take."""
+        projectPath = temp_dir / sample_project_name
+        projectPath.mkdir()
+
+        with caplog.at_level(logging.INFO):
+            updateProject(str(projectPath), dryRun=True)
+
+        assert "updating project" in caplog.text
+
+    def testBackupFileDryRunNoRename(self, temp_dir):
+        """Test that _backup_file in dry-run mode does not rename the original file."""
+        dest = temp_dir / "config.txt"
+        dest.write_text("original")
+
+        _backup_file(dest, dryRun=True)
+
+        assert dest.exists(), "Original file must not be renamed in dry-run mode"
+
+    def testCopyIfNewerDryRunNoWrite(self, temp_dir):
+        """Test that _copy_if_newer in dry-run mode does not write the destination file."""
+        src = temp_dir / "source.txt"
+        dest = temp_dir / "dest.txt"
+        src.write_text("new content")
+
+        _copy_if_newer(src, dest, dryRun=True)
+
+        assert not dest.exists(), "Destination file must not be created in dry-run mode"
+
+    def testUpdateTextFileDryRunNoWrite(self, temp_dir):
+        """Test that _update_text_file in dry-run mode does not write the file."""
+        dest = temp_dir / "output.txt"
+
+        _update_text_file(dest, "some content", dryRun=True)
+
+        assert not dest.exists(), "File must not be created in dry-run mode"

--- a/tests/testLogUtils.py
+++ b/tests/testLogUtils.py
@@ -174,7 +174,7 @@ class TestGetLoggerDryRun:
         assert isinstance(logger, logging.LoggerAdapter)
 
     def testGetLoggerDryRunPrefixApplied(self, tmp_path):
-        """Test that a logger from getLogger(dryRun=True) prefixes messages."""
+        """Test that a logger from getLogger(dryRun=True) prefixes action() messages."""
         logger = getLogger("testDryRunPrefix", logDir=tmp_path, dryRun=True)
         records: list[logging.LogRecord] = []
 
@@ -183,7 +183,7 @@ class TestGetLoggerDryRun:
                 records.append(record)
 
         logger.logger.addHandler(_Capture())
-        logger.info("moving file")
+        logger.action("moving file")
         assert records and "[] moving file" in records[0].getMessage()
 
     def testGetLoggerLiveNoPrefixApplied(self, tmp_path):
@@ -241,31 +241,45 @@ class TestSemanticLogMethods:
         logger.value("file count", 42)
         assert records and records[0].getMessage() == "...file count: 42"
 
-    def testValueDryRunPrefixInserted(self, tmp_path):
-        """Test that value() with dryRun inserts '[] ' after the '...'."""
+    def testValueDryRunNoPrefix(self, tmp_path):
+        """Test that value() does not insert dry-run prefix even when dryRun=True."""
         logger = getLogger("testValueDry", logDir=tmp_path, dryRun=True)
         records = self._captureRecords(logger)
         logger.value("file count", 42)
-        assert records and records[0].getMessage() == "...[] file count: 42"
+        assert records and records[0].getMessage() == "...file count: 42"
 
-    def testInfoDryRunPrefixInserted(self, tmp_path):
-        """Test that info() with dryRun inserts '[] ' after the '...'."""
+    def testInfoDryRunNoPrefix(self, tmp_path):
+        """Test that info() does not insert dry-run prefix even when dryRun=True."""
         logger = getLogger("testInfoDry", logDir=tmp_path, dryRun=True)
         records = self._captureRecords(logger)
         logger.info("moving file")
-        assert records and records[0].getMessage() == "...[] moving file"
+        assert records and records[0].getMessage() == "...moving file"
 
-    def testDoingDryRunPrefixInserted(self, tmp_path):
-        """Test that doing() with dryRun inserts '[] ' before the message."""
+    def testDoingDryRunNoPrefix(self, tmp_path):
+        """Test that doing() does not insert dry-run prefix even when dryRun=True."""
         logger = getLogger("testDoingDry", logDir=tmp_path, dryRun=True)
         records = self._captureRecords(logger)
         logger.doing("processing files")
-        assert records and records[0].getMessage() == "[] processing files..."
+        assert records and records[0].getMessage() == "processing files..."
 
-    def testDoneDryRunPrefixInserted(self, tmp_path):
-        """Test that done() with dryRun inserts '[] ' after the '...'."""
+    def testDoneDryRunNoPrefix(self, tmp_path):
+        """Test that done() does not insert dry-run prefix even when dryRun=True."""
         logger = getLogger("testDoneDry", logDir=tmp_path, dryRun=True)
         records = self._captureRecords(logger)
         logger.done("processing files")
-        assert records and records[0].getMessage() == "...[] processing files"
+        assert records and records[0].getMessage() == "...processing files"
+
+    def testActionDryRunPrefixInserted(self, tmp_path):
+        """Test that action() inserts '[] ' prefix when dryRun=True."""
+        logger = getLogger("testActionDry", logDir=tmp_path, dryRun=True)
+        records = self._captureRecords(logger)
+        logger.action("moving file")
+        assert records and records[0].getMessage() == "...[] moving file"
+
+    def testActionLiveNoPrefixInserted(self, tmp_path):
+        """Test that action() does not insert '[] ' prefix when dryRun=False."""
+        logger = getLogger("testActionLive", logDir=tmp_path, dryRun=False)
+        records = self._captureRecords(logger)
+        logger.action("moving file")
+        assert records and records[0].getMessage() == "...moving file"
 

--- a/tests/testLogUtils.py
+++ b/tests/testLogUtils.py
@@ -11,7 +11,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from organiseMyProjects.logUtils import _defaultLogDir, drawBox, getLogger
+from organiseMyProjects.logUtils import _defaultLogDir, drawBox, getLogger, thisApplication
 
 
 class TestDefaultLogDir:
@@ -26,10 +26,10 @@ class TestDefaultLogDir:
         """Test that getLogger uses ~/.local/state/{name}/{name}-{date}.log structure."""
         import organiseMyProjects.logUtils as logUtils
         monkeypatch.setattr(logUtils, "_defaultLogDir", lambda: tmp_path)
-        name = "testAppName"
-        logger = getLogger(name)
+        monkeypatch.setattr(logUtils, "thisApplication", "testAppName")
+        logger = getLogger(logUtils.thisApplication)
         expectedDate = datetime.date.today().isoformat()
-        expectedFile = tmp_path / name / f"{name}-{expectedDate}.log"
+        expectedFile = tmp_path / logUtils.thisApplication / f"{logUtils.thisApplication}-{expectedDate}.log"
         assert expectedFile.exists(), f"Expected log file {expectedFile} was not created"
 
 


### PR DESCRIPTION
- [x] Fix `logUtils.py` `_setupLogging`: use `type(h) is logging.StreamHandler` (exact match) — `FileHandler` is a subclass of `StreamHandler` so `isinstance` was blocking the console handler from ever being added
- [x] Fix `logUtils.py` `_OrganiseLoggerAdapter`: remove `self._prefix` from `process()` — only `action()` carries the dry-run prefix; `info/doing/done/value` and non-semantic calls pass through unchanged
- [x] Update `tests/testLogUtils.py`: `testGetLoggerDryRunPrefixApplied` now tests `action()`, four "DryRunPrefixInserted" tests replaced with "NoDryRunPrefix" counterparts, two new `testActionDryRunPrefixInserted` / `testActionLiveNoPrefixInserted` tests added
- [x] All 58 tests passing